### PR TITLE
cmd/mdreplace: update pkg docs with README link for more info

### DIFF
--- a/cmd/mdreplace/README.md
+++ b/cmd/mdreplace/README.md
@@ -18,33 +18,36 @@ are replaced with command output.
 
 For example, were we to include the following special comment block:
 
-```
-<!-- __TEMPLATE: echo -n "hello world" today
-{{.}}
+<!-- __TEMPLATE: cat _examples/hello_world_today
+{{. -}}
 -->
+    <!-- __TEMPLATE: echo -n "hello world" today
+    {{. -}}
+    -->
+    <!-- END -->
 <!-- END -->
-```
 
-then this is what would result (see the [source of the
-`README.md`](https://raw.githubusercontent.com/myitcv/x/master/cmd/mdreplace/README.md) you are currently reading):
+results in:
 
 ---
-<!-- __TEMPLATE: echo -n "hello world" today
+<!-- __TEMPLATE: sh -c "cat _examples/hello_world_today | sed -e 's/^    //' | mdreplace -strip"
 {{.}}
 -->
 hello world today
 <!-- END -->
 ---
 
-The `__TEMPLATE` block provides the following template functions:
-
-* `lines(string) []string` - split a string into lines
+_To see this in action, look at the [source of the
+`README.md`](https://raw.githubusercontent.com/myitcv/x/master/cmd/mdreplace/README.md) you are currently reading._
 
 
 ### Code fences
 
 Code fences can appear within templates. Hence the following special template within a markdown file:
 
+<!-- __TEMPLATE: cat _examples/code_fence
+{{. -}}
+-->
     <!-- __TEMPLATE: echo -n "hello world"
     ```go
     package main
@@ -57,20 +60,13 @@ Code fences can appear within templates. Hence the following special template wi
     ```
     -->
     <!-- END -->
+<!-- END -->
 
 results in:
 
 ---
-<!-- __TEMPLATE: echo -n "hello world"
-```go
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("{{.}}")
-}
-```
+<!-- __TEMPLATE: sh -c "cat _examples/code_fence | sed -e 's/^    //' | mdreplace -strip"
+{{.}}
 -->
 ```go
 package main
@@ -78,12 +74,12 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("hello world")
+        fmt.Println("hello world")
 }
 ```
+
 <!-- END -->
 ---
-
 
 
 The only place that special comment blocks are _not_ interpreted by `mdreplace` is within code blocks. Hence how we are
@@ -91,27 +87,70 @@ able to render the example special code blocks in this README.
 
 _Note it is not possible to nest code fences._
 
+### JSON blocks
+
+The `__JSON` block is used where the output from the command is valid JSON. This JSON is then unmarshalled and passed as
+an argument to the template block. For example:
+
+<!-- __TEMPLATE: cat _examples/json_block
+{{. -}}
+-->
+    <!-- __JSON: go list -json encoding/json
+    Package `{{.ImportPath}}` has name `{{.Name}}` and the following doc string:
+
+    ```
+    {{.Doc}}
+    ```
+    -->
+    <!-- END -->
+<!-- END -->
+
+results in :
+
+---
+<!-- __TEMPLATE: sh -c "cat _examples/json_block | sed -e 's/^    //' | mdreplace -strip"
+{{.}}
+-->
+Package `encoding/json` has name `json` and the following doc string:
+
+```
+Package json implements encoding and decoding of JSON as defined in RFC 7159.
+```
+
+<!-- END -->
+---
 
 ### Variable expansion
 
-Variable expansion also works; use the special `$DOLLAR` variable to get expand to the literal `$` sign:
+Variable expansion also works; use the special `$DOLLAR` variable to expand to the literal `$` sign:
 
-```
-<!-- __TEMPLATE: sh -c "BANANA=fruit; echo -n \"${DOLLAR}BANANA\""
-{{.}}
+<!-- __TEMPLATE: cat _examples/variable_expansion
+{{. -}}
 -->
+    <!-- __TEMPLATE: sh -c "BANANA=fruit; echo -n \"${DOLLAR}BANANA\""
+    {{.}}
+    -->
+    <!-- END -->
 <!-- END -->
-```
 
-results in:
+results in :
 
 ---
-<!-- __TEMPLATE: sh -c "BANANA=fruit; echo -n \"${DOLLAR}BANANA\""
+<!-- __TEMPLATE: sh -c "cat _examples/variable_expansion | sed -e 's/^    //' | mdreplace -strip"
 {{.}}
 -->
 fruit
+
 <!-- END -->
 ---
+
+### Template functions
+
+Both the `__TEMPLATE` and `__JSON` blocks support the following template functions:
+
+* `lines(string) []string` - split a string into lines
+* ... more to follow
+
 
 ### Implementation
 

--- a/cmd/mdreplace/_examples/code_fence
+++ b/cmd/mdreplace/_examples/code_fence
@@ -1,0 +1,12 @@
+    <!-- __TEMPLATE: echo -n "hello world"
+    ```go
+    package main
+
+    import "fmt"
+
+    func main() {
+            fmt.Println("{{.}}")
+    }
+    ```
+    -->
+    <!-- END -->

--- a/cmd/mdreplace/_examples/hello_world_today
+++ b/cmd/mdreplace/_examples/hello_world_today
@@ -1,0 +1,4 @@
+    <!-- __TEMPLATE: echo -n "hello world" today
+    {{. -}}
+    -->
+    <!-- END -->

--- a/cmd/mdreplace/_examples/json_block
+++ b/cmd/mdreplace/_examples/json_block
@@ -1,0 +1,8 @@
+    <!-- __JSON: go list -json encoding/json
+    Package `{{.ImportPath}}` has name `{{.Name}}` and the following doc string:
+
+    ```
+    {{.Doc}}
+    ```
+    -->
+    <!-- END -->

--- a/cmd/mdreplace/_examples/variable_expansion
+++ b/cmd/mdreplace/_examples/variable_expansion
@@ -1,0 +1,4 @@
+    <!-- __TEMPLATE: sh -c "BANANA=fruit; echo -n \"${DOLLAR}BANANA\""
+    {{.}}
+    -->
+    <!-- END -->

--- a/cmd/mdreplace/common_block.go
+++ b/cmd/mdreplace/common_block.go
@@ -101,7 +101,9 @@ Args:
 		p.errorf("failed to parse template %q: %e", tmpl, err)
 	}
 
-	p.printf(prefix+" %v\n%v"+commEnd+"\n", origCmdStr, tmpl)
+	if !*fStrip {
+		p.printf(prefix+" %v\n%v"+commEnd+"\n", origCmdStr, tmpl)
+	}
 
 	i := conv(out)
 
@@ -109,7 +111,9 @@ Args:
 		p.errorf("failed to execute template %q with input %q: %v", tmpl, i, err)
 	}
 
-	p.println(blockEnd)
+	if !*fStrip {
+		p.println(blockEnd)
+	}
 
 	return p.processText
 }


### PR DESCRIPTION
Also:

* run `mdreplace` in the directory of any files it processes
* make the `README.md` file for `mdreplace` itself self-healing
* Include a `__JSON` block example
* Include a `-strip` flag to help with the self-healing `README.md`