### PR TITLE
immutable/cmd/immutableVet: use vgo.Loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,11 @@ Please note the following packages current rely on `vgo` with https://go-review.
 ```
 {{end -}}
 -->
+
+Please note the following packages current rely on `vgo` with https://go-review.googlesource.com/c/vgo/+/105855 applied:
+
+```
+myitcv.io/immutable/cmd/immutableVet
+```
 <!-- END -->
 

--- a/immutable/_scripts/run_tests.sh
+++ b/immutable/_scripts/run_tests.sh
@@ -10,20 +10,14 @@ rm -f !(_vendor)/**/gen_*.go
 $go install myitcv.io/immutable/cmd/immutableGen
 $go install myitcv.io/immutable/cmd/immutableVet
 
+# this step is needed because _testFiles is not walked by ./...
 pushd cmd/immutableVet/_testFiles
 $go generate
 popd
 
 $go generate ./...
-
-# for immutable this step needs to be before the tests (because some of the
-# tests rely on the myitcv.io/immutable package to have been installed)
-
-# we can remove this once we resolve https://github.com/golang/go/issues/24661
-$go install ./...
-
 $go test ./...
 
+$go install myitcv.io/immutable/cmd/immutableVet
 
 immutableVet myitcv.io/immutable/example
-

--- a/immutable/go.mod
+++ b/immutable/go.mod
@@ -3,5 +3,10 @@ module "myitcv.io/immutable"
 require (
 	"github.com/kisielk/gotool" v1.0.0
 	"golang.org/x/tools" v0.0.0-20180401165715-ac136b6c2db7
-	"myitcv.io/gogenerate" v0.0.0-20180405194116-cdcde380fd71d44b727692b77c152bb2e9df079c
+	"myitcv.io/gogenerate" v0.0.0-20170415175604-bd69a94c9695
+	"myitcv.io/vgo" v0.0.0
+)
+
+replace (
+	"myitcv.io/vgo" v0.0.0 => "../vgo"
 )


### PR DESCRIPTION
Depends on #10 - at which point we can [remove this override](https://github.com/myitcv/x/blob/imm_vgo_loader/immutable/go.mod#L10-L12)