### PR TITLE
ci: add build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,15 @@ notifications:
 matrix:
   include:
     - env: CHROMEDRIVER_VERSION=2.40 CHROME_CHANNEL=beta
+      go: 1.10.x
       addons:
         chrome: beta
-
-go:
-  - stable
 
 go_import_path: myitcv.io
 
 before_script:
-  - go version
+  - ./_scripts/install_go.sh
   - ./_scripts/setupCIEnv.sh
-  - mkdir /tmp/google-chrome-bin && ln -s /usr/bin/google-chrome-$CHROME_CHANNEL /tmp/google-chrome-bin/google-chrome && export PATH=/tmp/google-chrome-bin:$PATH
 
 install: true
 

--- a/_scripts/common.bash
+++ b/_scripts/common.bash
@@ -15,13 +15,6 @@ set -o pipefail
 # See https://www.gnu.org/software/bash/manual/html_node/Shell-Functions.html#Shell-Functions
 set -o errtrace
 
-# We assume that PATH will have been setup in such a way as to leave
-# the correct version of go in place. This allows us to test multiple
-# versions of Go via CI or to "pin" via go version, e.g. the logic that
-# sets up our _vendor GOPATH or not:
-
-source "${BASH_SOURCE%/*}/setupGOPATH.bash"
-
 shopt -s globstar
 shopt -s extglob
 
@@ -39,43 +32,7 @@ error() {
 
 trap 'set +u; error "${LINENO}" "${BASH_SOURCE}"' ERR
 
-running_on_ci_server()
-{
-	set +u
-	local res
-	if [ "$TRAVIS" == "true" ]
-	then
-		res=yes
-	else
-		res=no
-	fi
-	set -u
-	echo $res
-}
-export -f running_on_ci_server
-
-only_run_on_ci_server()
-{
-	if [ $(running_on_ci_server) != "yes" ]
-	then
-		echo "This script can ONLY be run on the CI server"
-		exit 1
-	fi
-}
-export -f only_run_on_ci_server
-
-# Some CI-only env setup
-
-if [ $(running_on_ci_server) == "yes" ]
-then
-	# TODO ensure the go build cache is also cache
-	export CI_CACHE_DIR=~/cache
-	export CI_DEPENDENCIES_DIR=$CI_CACHE_DIR/depedencies
-
-	export PROTOBUF_INSTALL_DIR=$CI_DEPENDENCIES_DIR/protobuf
-
-	export CHROMEDRIVER_INSTALL_DIR=$CI_DEPENDENCIES_DIR/chromedriver
-fi
+source "${BASH_SOURCE%/*}/commonFunctions.bash"
 
 # The env setup is intentionally separate into a separate file
 # so that we can safely source it from scripts that could be
@@ -83,11 +40,27 @@ fi
 
 source "${BASH_SOURCE%/*}/commonEnv.bash"
 
+# Here we "override" the version of Go if USE_GO_TIP is set.
+# This is needed where a Go version is not available via Travis
+
+if [ $(running_on_ci_server) == "yes" ]
+then
+	# Travis bug with GOROOT
+	unset GOROOT
+	if [ "${USE_GO_TIP:-}" == "true" ]
+	then
+		export PATH="$HOME/gotip/bin:$PATH"
+	fi
+fi
+
+# We assume that PATH will have been setup in such a way as to leave
+# the correct version of go in place. This allows us to test multiple
+# versions of Go via CI or to "pin" via go version, e.g. the logic that
+# sets up our _vendor GOPATH or not:
+source "${BASH_SOURCE%/*}/setupGOPATH.bash"
 
 # TODO switch to using gg
-
 gg="go generate"
-
 
 # *****************************************
 LOADED_COMMON_BASH="true"

--- a/_scripts/commonEnv.bash
+++ b/_scripts/commonEnv.bash
@@ -2,23 +2,44 @@
 # version. This allows us to test a multitude of different protobuf versions
 # via CI
 
-autostash_or_export()
-{
-	if [ "$(type -t autostash || true)" == "function" ]
+if [ "${LOADED_COMMON_ENV:-}" == "true" ]
+then
+	return
+fi
+
+source "${BASH_SOURCE%/*}/commonFunctions.bash"
+
+# Some CI-only env setup
+
+if [ $(running_on_ci_server) == "yes" ]
+then
+	# TODO ensure the go build cache is also cache
+	export CI_CACHE_DIR=~/cache
+	export CI_DEPENDENCIES_DIR=$CI_CACHE_DIR/depedencies
+
+	export PROTOBUF_INSTALL_DIR=$CI_DEPENDENCIES_DIR/protobuf
+
+	export CHROMEDRIVER_INSTALL_DIR=$CI_DEPENDENCIES_DIR/chromedriver
+
+	# gross hack because Travis does not update the google-chrome alternative
+	# properly
+	if [ ! -d /tmp/google-chrome-bin ]
 	then
-		autostash "$@"
-	else
-		export "$@"
+		mkdir /tmp/google-chrome-bin
+		ln -s /usr/bin/google-chrome-$CHROME_CHANNEL /tmp/google-chrome-bin/google-chrome
 	fi
-}
+	export PATH=/tmp/google-chrome-bin:$PATH
+fi
 
 if [ "${PROTOBUF_VERSION:-}" == "" ]
 then
-	autostash_or_export PROTOBUF_VERSION="$(cat .dependencies/protobuf_version)"
+	autostash_or_export PROTOBUF_VERSION="$(cat "${BASH_SOURCE%/*}/../.dependencies/protobuf_version")"
 fi
 if [ "${CHROMEDRIVER_VERSION:-}" == "" ]
 then
-	autostash_or_export CHROMEDRIVER_VERSION="$(cat .dependencies/chromedriver_version)"
+	autostash_or_export CHROMEDRIVER_VERSION="$(cat "${BASH_SOURCE%/*}/../.dependencies/chromedriver_version")"
 fi
 
 autostash_or_export PROTOBUF_INCLUDE="$PROTOBUF_INSTALL_DIR/$PROTOBUF_VERSION/include"
+
+LOADED_COMMON_ENV=true

--- a/_scripts/commonFunctions.bash
+++ b/_scripts/commonFunctions.bash
@@ -1,0 +1,40 @@
+if [ "${LOADED_COMMON_FUNCTIONS:-}" == "true" ]
+then
+	return
+fi
+
+autostash_or_export()
+{
+	if [ "$(type -t autostash || true)" == "function" ]
+	then
+		autostash "$@"
+	else
+		export "$@"
+	fi
+}
+export -f autostash_or_export
+
+running_on_ci_server()
+{
+	local res
+	if [ "${TRAVIS:-}" == "true" ]
+	then
+		res=yes
+	else
+		res=no
+	fi
+	echo $res
+}
+export -f running_on_ci_server
+
+only_run_on_ci_server()
+{
+	if [ $(running_on_ci_server) != "yes" ]
+	then
+		echo "This script can ONLY be run on the CI server"
+		exit 1
+	fi
+}
+export -f only_run_on_ci_server
+
+LOADED_COMMON_FUNCTIONS=true

--- a/_scripts/install_go.sh
+++ b/_scripts/install_go.sh
@@ -2,22 +2,20 @@
 
 source "${BASH_SOURCE%/*}/common.bash"
 
+trap "go version" EXIT
+
+if [ "${USE_GO_TIP:-}" != "true" ]
+then
+	# nothing to do
+	exit
+fi
+
+source="https://github.com/myitcv/gobuilds/raw/master/linux_amd64/$GO_TIP_VERSION.tar.gz"
 target=$HOME/gotip
 
-echo "Will install ${GOTIP_VERSION:0:10} from $GOTIP_REPO to $target"
+echo "Will install ${GO_TIP_VERSION:0:10} from $source to $target"
 
 mkdir -p $target
 cd $target
 
-if [ ! -e .git ]
-then
-	echo cloning
-	git clone -q $GOTIP_REPO .
-else
-	echo fetching
-	git fetch -q $GOTIP_REPO
-fi
-
-git checkout -qf $GOTIP_VERSION
-cd src
-GOROOT_BOOTSTRAP=$(go env GOROOT) ./make.bash
+curl -L -s $source | tar -xz

--- a/_scripts/setupGOPATH.bash
+++ b/_scripts/setupGOPATH.bash
@@ -4,26 +4,21 @@
 #
 # It also ensures that GOBIN is suitably set and PATH updated to include GOBIN.
 
+source "${BASH_SOURCE%/*}/commonFunctions.bash"
+
 if [ "${LOADED_SETUP_GOPATH:-}" == "true" ]
 then
 	return
 fi
 
-if [ "$(type -t autostash || true)" == "function" ]
-then
-	autostash GOBIN="$(readlink -m "${BASH_SOURCE%/*}/../.bin")"
-else
-	export GOBIN="$(readlink -m "${BASH_SOURCE%/*}/../.bin")"
-fi
+autostash_or_export GOBIN="$(readlink -m "${BASH_SOURCE%/*}/../.bin")"
 
-if [[ "$(go version | cut -d ' ' -f 3)" =~ go1.(9|10).[0-9]+ ]]
+# Pre Go 1.11 check
+# [[ "$(go version | cut -d ' ' -f 3)" =~ go1.(9|10).[0-9]+ ]]
+
+if [ "${GO111MODULE:-}" != "on" ]
 then
-	if [ "$(type -t autostash || true)" == "function" ]
-	then
-		autostash GOPATH="$(readlink -m "${BASH_SOURCE%/*}/../_vendor"):$GOPATH"
-	else
-		export GOPATH="$(readlink -m "${BASH_SOURCE%/*}/../_vendor"):$GOPATH"
-	fi
+	autostash_or_export GOPATH="$(readlink -m "${BASH_SOURCE%/*}/../_vendor"):$GOPATH"
 fi
 
 LOADED_SETUP_GOPATH=true


### PR DESCRIPTION
Adds initial support for a build matrix. We will add Go 1.11 into a branch