### PR TITLE
cmd/egrunner: more efficient docker image

### DIFF
--- a/cmd/egrunner/main.go
+++ b/cmd/egrunner/main.go
@@ -439,10 +439,22 @@ ENV GOPATH=/home/gopher/gopath
 RUN groupadd -g %[2]v gopher && \
     adduser --uid %[1]v --gid %[2]v --disabled-password --gecos "" gopher
 
+# install sudo
+RUN apt-get update
+RUN apt-get install -y sudo tree
+
 # enable sudo
 RUN usermod -aG sudo gopher
-RUN mkdir /etc/sudoers.d
-RUN echo "gopher ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/gopher
+RUN echo "gopher ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/gopher
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN apt-get update
+RUN apt-get install -y docker-ce
+
+RUN usermod -aG docker gopher
 
 USER gopher
 `


### PR DESCRIPTION
Install:

* docker
* tree

and ensure the gopher user is part of the sudo-ers and docker groups.