### PR TITLE
react/examples/sites/syntaxviewer: parse comments in Shell mode.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,5 @@ require (
 	mvdan.cc/sh v2.5.0+incompatible
 )
 
-// branch: go1.11
-replace github.com/gopherjs/gopherjs => github.com/myitcv/gopherjs v0.0.0-20180901025010-55c28f202f5a
+// branch: master
+replace github.com/gopherjs/gopherjs => github.com/myitcv/gopherjs v0.0.0-20181106113007-59ba804b0d30

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/myitcv/gopherjs v0.0.0-20180901025010-55c28f202f5a h1:xDPvR7p32NDzEYDDNA2sKQXL0Ti5GzxV/buTX+UgDK4=
-github.com/myitcv/gopherjs v0.0.0-20180901025010-55c28f202f5a/go.mod h1:1g7lnQbUhuEAnecgQEWZEJsnB2z97hGFK+VRzCLun+0=
+github.com/myitcv/gopherjs v0.0.0-20181106113007-59ba804b0d30 h1:ZGxBik0evtvAinQthsLvCU0nQyYcK1tv+d0KoyIitGo=
+github.com/myitcv/gopherjs v0.0.0-20181106113007-59ba804b0d30/go.mod h1:X83RgTaopDGeqahgXrQ120BVA5Ztn+oW4kxNueqOja4=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86 h1:D6paGObi5Wud7xg83MaEFyjxQB1W5bz5d0IFppr+ymk=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab h1:eFXv9Nu1lGbrNbj619aWwZfVF5HBrm9Plte8aNptuTI=
@@ -45,8 +45,8 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 h1:SWV2fHctRpRrp49VXJ6UZja7gU9QLHwRpIPBN89SKEo=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
-github.com/shurcooL/vfsgen v0.0.0-20180711163814-62bca832be04 h1:y0cMJ0qjii33BnD6tMGcF/+gHYsoKQ6tbwQpy233OII=
-github.com/shurcooL/vfsgen v0.0.0-20180711163814-62bca832be04/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
+github.com/shurcooL/vfsgen v0.0.0-20180915214035-33ae1944be3f h1:kIuU4/Y7SabSYfMsN3BZWTCCeH5n9ikoZ9ezHJPLwHM=
+github.com/shurcooL/vfsgen v0.0.0-20180915214035-33ae1944be3f/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=

--- a/react/examples/sites/syntaxviewer/app.go
+++ b/react/examples/sites/syntaxviewer/app.go
@@ -229,7 +229,7 @@ func (a AppDef) handleEvent() {
 
 	case langShell:
 		in := strings.NewReader(st.Code())
-		f, err := syntax.NewParser().Parse(in, "stdin")
+		f, err := syntax.NewParser(syntax.KeepComments).Parse(in, "stdin")
 		if err != nil {
 			st.SetAst(err.Error())
 			return


### PR DESCRIPTION
Also bump to using the latest version of github.com/myitcv/gopherjs.