### PR TITLE
cmd/egrunner: simplify checking for shell asserts

### DIFF
--- a/cmd/egrunner/main.go
+++ b/cmd/egrunner/main.go
@@ -365,25 +365,13 @@ FinishedLookupGithubCLI:
 		}
 		isAssert := false
 		if ce, ok := s.Cmd.(*syntax.CallExpr); ok {
-			if ce.Args != nil && ce.Args[0].Parts != nil {
-				if li, ok := ce.Args[0].Parts[0].(*syntax.Lit); ok {
-					if li.Value == "assert" {
-						isAssert = true
-					}
-				}
-			}
+			isAssert = len(ce.Args) > 0 && ce.Args[0].Lit() == "assert"
 		}
 		nextIsAssert := false
 		if si < len(f.Stmts)-1 {
 			s := f.Stmts[si+1]
 			if ce, ok := s.Cmd.(*syntax.CallExpr); ok {
-				if ce.Args != nil && ce.Args[0].Parts != nil {
-					if li, ok := ce.Args[0].Parts[0].(*syntax.Lit); ok {
-						if li.Value == "assert" {
-							nextIsAssert = true
-						}
-					}
-				}
+				nextIsAssert = len(ce.Args) > 0 && ce.Args[0].Lit() == "assert"
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	honnef.co/go/js/dom v0.0.0-20180323154144-6da835bec70f
 	honnef.co/go/js/util v0.0.0-20150216223935-96b8dd9d1621 // indirect
 	honnef.co/go/js/xhr v0.0.0-20150307031022-00e3346113ae
-	mvdan.cc/sh v2.5.0+incompatible
+	mvdan.cc/sh v2.6.0+incompatible
 )
 
 // branch: master

--- a/go.sum
+++ b/go.sum
@@ -88,5 +88,5 @@ honnef.co/go/js/util v0.0.0-20150216223935-96b8dd9d1621 h1:QBApQyt1KyR3SvDWU8sHc
 honnef.co/go/js/util v0.0.0-20150216223935-96b8dd9d1621/go.mod h1:WrAIh8rWfzvMdLVgQ7vpu7aYbDAZ3rHLxydzv2VkL/w=
 honnef.co/go/js/xhr v0.0.0-20150307031022-00e3346113ae h1:2dIKMawnBWvHzZrS8STyu/KdhYIOpnKQpp1WZm+K7TE=
 honnef.co/go/js/xhr v0.0.0-20150307031022-00e3346113ae/go.mod h1:QwoYXdHZpuR080H32s5jqyk7zh/k/U9bDFg2g8OMmOM=
-mvdan.cc/sh v2.5.0+incompatible h1:JNM6l18iQFGZl0dK2n/7Z85sNaFq9zSl3qooNNyl+qA=
-mvdan.cc/sh v2.5.0+incompatible/go.mod h1:IeeQbZq+x2SUGBensq/jge5lLQbS3XT2ktyp3wrt4x8=
+mvdan.cc/sh v2.6.0+incompatible h1:BLDuJ+D75OCaBF7W70+2oALi8aKAjcAiDBNmmwR8BQA=
+mvdan.cc/sh v2.6.0+incompatible/go.mod h1:IeeQbZq+x2SUGBensq/jge5lLQbS3XT2ktyp3wrt4x8=


### PR DESCRIPTION
mvdan.cc/sh version 2.6 adds syntax.Word.Lit, which makes it trivial to
check if a word is simply an unquoted literal. Update the dependency and
remove the now unnecessary reflection code.