### PR TITLE
cmd/(unsharemounts|mountwrap): fix usage of unshare

### DIFF
--- a/cmd/mountwrap/main.go
+++ b/cmd/mountwrap/main.go
@@ -73,12 +73,7 @@ func main() {
 			fmt.Printf("Error performing setuid: %v\n", err)
 			os.Exit(1)
 		}
-		out, err := exec.Command("/bin/mount", "--make-private", "/").CombinedOutput()
-		if err != nil {
-			fmt.Printf("Error performing make-private on /: %v\n", err)
-			os.Exit(1)
-		}
-		out, err = exec.Command("/bin/mount", "-n", "--bind", old_dir, new_dir).CombinedOutput()
+		out, err := exec.Command("/bin/mount", "-n", "--bind", old_dir, new_dir).CombinedOutput()
 		if err != nil {
 			fmt.Printf("Error performing mount: %v\n", err)
 			os.Exit(1)

--- a/cmd/unsharemounts/main.go
+++ b/cmd/unsharemounts/main.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Paul Jolly <paul@myitcv.org.uk>, all rights reserved.
 // Use of this document is governed by a license found in the LICENSE document.
 
+//go:build linux
 // +build linux
 
 package main
@@ -10,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"runtime"
 	"strings"
@@ -45,6 +47,17 @@ func main() {
 
 	if err := syscall.Unshare(CLONE_NEWNS); err != nil {
 		fmt.Printf("Could not unshare: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = syscall.Setreuid(0, 0)
+	if err != nil {
+		fmt.Printf("Error performing setuid: %v\n", err)
+		os.Exit(1)
+	}
+	out, err := exec.Command("/bin/mount", "--make-private", "/home").CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error performing make-private on /: %v\n%s", err, out)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
With the move to Debian, we now mount /home onto a separate device. This means that the old approach of calling --make-private on / no longer works, because /home is still shared.

It's also unclear how calling mount --make-private / worked, because this happened in a child process of the shell in which we had previously called unshare.

Looking at the example in unshare(1), that seems to suggest the call to unshare and the call to mount --make-private should happen in the parent/current process. Mainly because repeatedly making that call will have no effect - calling it once should suffice.

The docs in unshare(1) are also somewhat unclear on the order in which the calls should be made:

  $ mount --bind /root/namespaces /root/namespaces
  $ mount --make-private /root/namespaces
  $ touch /root/namespaces/mnt
  $ unshare --mount=/root/namespaces/mnt

For now it seems like the most sensible thing to do is to call unshare first (to create a separate mount namespace), then make the mount private to the new namespace.

Also fix up newshell. There is lots of bad code in this repo, much hard coding of values... but for now it works again.